### PR TITLE
add open method in WorkerLogic trait

### DIFF
--- a/src/main/scala/hu/sztaki/ilab/ps/FlinkParameterServer.scala
+++ b/src/main/scala/hu/sztaki/ilab/ps/FlinkParameterServer.scala
@@ -228,6 +228,7 @@ object FlinkParameterServer {
 
 
             override def open(parameters: Configuration): Unit = {
+              logic.open()
               psClient.setPartitionId(getRuntimeContext.getIndexOfThisSubtask)
             }
 

--- a/src/main/scala/hu/sztaki/ilab/ps/WorkerLogic.scala
+++ b/src/main/scala/hu/sztaki/ilab/ps/WorkerLogic.scala
@@ -20,6 +20,11 @@ import scala.util.{Success, Try}
 trait WorkerLogic[T, P, WOut] extends Serializable {
 
   /**
+    * Method called when the Flink operator is created
+    */
+  def open(): Unit ={}
+
+  /**
     * Method called when new data arrives.
     *
     * @param data


### PR DESCRIPTION
Add open() method in WorkerLogic trait in order to let the programmer implement some logic that will be compute when the Flink operator is create